### PR TITLE
:bug: 指定使用Onebot v11

### DIFF
--- a/nonebot_plugin_learning_chat/__init__.py
+++ b/nonebot_plugin_learning_chat/__init__.py
@@ -2,8 +2,8 @@ import asyncio
 import random
 import time
 
-from nonebot import on_message, get_bot, require, logger
-from nonebot.adapters.onebot.v11 import GroupMessageEvent, GROUP, Message, ActionFailed
+from nonebot import on_message, require, logger, get_adapter
+from nonebot.adapters.onebot.v11 import GroupMessageEvent, GROUP, Message, ActionFailed, Adapter
 from nonebot.params import Arg
 from nonebot.plugin import PluginMetadata
 from nonebot.rule import Rule
@@ -80,7 +80,10 @@ async def speak_up():
     if not config_manager.config.total_enable:
         return
     try:
-        bot = get_bot()
+        bots = get_adapter(Adapter).bots
+        if len(bots) == 0:
+            return
+        bot = list(bots.values())[0]
     except ValueError:
         return
     if not (speak := await LearningChat.speak(int(bot.self_id))):

--- a/nonebot_plugin_learning_chat/handler.py
+++ b/nonebot_plugin_learning_chat/handler.py
@@ -11,8 +11,8 @@ except ImportError:
     import jieba.analyse as jieba_analyse
 from typing import List, Union, Optional, Tuple
 from enum import IntEnum, auto
-from nonebot import get_bot
-from nonebot.adapters.onebot.v11 import GroupMessageEvent, MessageSegment, ActionFailed
+from nonebot import get_adapter
+from nonebot.adapters.onebot.v11 import GroupMessageEvent, MessageSegment, ActionFailed, Adapter
 from tortoise.functions import Count
 from .models import ChatBlackList, ChatContext, ChatAnswer, ChatMessage
 from .config import (
@@ -330,7 +330,10 @@ class LearningChat:
 
     async def _ban(self, message_id: Optional[int] = None) -> bool:
         """屏蔽消息"""
-        bot = get_bot()
+        bots = get_adapter(Adapter).bots
+        if len(bots) == 0:
+            return False
+        bot = list(bots.values())[0]
         if message_id:
             if (
                 not (message := await ChatMessage.filter(message_id=message_id).first())


### PR DESCRIPTION
在实际使用的时候遇到一个情况，`get_bots()`获取的默认第一顺位不支持群聊的bot，在使用如`send_group_msg()`之类的函数时会报错。
修改后指定使用Onebot V11 adapter的第一个bot以防出现类似兼容错误